### PR TITLE
Fix CubeEnv Observation Space

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rrc_simulation</name>
-  <version>0.0.1</version>
+  <version>1.0.1</version>
   <description>
       pyBullet simulation for the Finger, TriFinger and related robots.
   </description>

--- a/python/rrc_simulation/gym_wrapper/envs/cube_env.py
+++ b/python/rrc_simulation/gym_wrapper/envs/cube_env.py
@@ -129,7 +129,7 @@ class CubeEnv(gym.GoalEnv):
 
         object_state_space = gym.spaces.Dict(
             {
-                "position": spaces.robot_torque.gym,
+                "position": spaces.object_position.gym,
                 "orientation": spaces.object_orientation.gym,
             }
         )

--- a/tests/test_cube_env.py
+++ b/tests/test_cube_env.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import unittest
+
+from rrc_simulation.gym_wrapper.envs import cube_env
+
+
+class TestSample(unittest.TestCase):
+    """Test the CubeEnv gym environment."""
+
+    def test_if_observations_are_valid(self):
+        # Observations need to be contained in the observation space.  If this
+        # is not the case, there is either an issue with the  generation of the
+        # observations or the observation space is not defined properly.
+        env = cube_env.CubeEnv(cube_env.RandomInitializer(4))
+
+        observation = env.reset()
+        self.assertTrue(env.observation_space.contains(observation))
+
+        for i in range(3000):
+            action = env.action_space.sample()
+            observation, _, _, _ = env.step(action)
+
+            self.assertTrue(env.observation_space.contains(observation))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Fix wrong observation space for object position (reported [here](https://real-robot-challenge.trydiscourse.com/t/incorrect-observation-space-for-desired-goal-achieved-goal/67)).

Also add unit test catching this error and making sure it is fixed now.

# How I Tested
By running all unit tests (including the new one) and inspecting the observation space manually.