### PR TITLE
Ensure members of returned actions and observations are always numpy arrays

### DIFF
--- a/python/rrc_simulation/action.py
+++ b/python/rrc_simulation/action.py
@@ -28,8 +28,8 @@ class Action:
             kp:  See :attr:`kp`.
             kd:  See :attr:`kd`.
         """
-        self.torque = torque
-        self.position = position
+        self.torque = np.asarray(torque)
+        self.position = np.asarray(position)
 
         if kp is None:
             self.position_kp = np.full_like(position, np.nan, dtype=float)

--- a/python/rrc_simulation/sim_finger.py
+++ b/python/rrc_simulation/sim_finger.py
@@ -354,9 +354,7 @@ class SimFinger:
                 )
             )
 
-        applied_action.torque = self.__safety_check_torques(
-            torque_command.tolist()
-        )
+        applied_action.torque = self.__safety_check_torques(torque_command)
 
         self.__set_pybullet_motor_torques(applied_action.torque)
 
@@ -395,11 +393,11 @@ class SimFinger:
         the motors so that they do not exceed the safety torque limit
 
         Args:
-            desired_torques (list of floats): The torques desired to be
+            desired_torques (array): The torques desired to be
                 applied to the motors
 
         Returns:
-            applied_torques (list of floats): The torques that can be actually
+            applied_torques (array): The torques that can be actually
             applied to the motors (and will be applied)
         """
         applied_torques = np.clip(
@@ -416,12 +414,10 @@ class SimFinger:
         )
         applied_torques -= self.safety_kd * current_velocity
 
-        applied_torques = list(
-            np.clip(
-                np.asarray(applied_torques),
-                -self.max_motor_torque,
-                +self.max_motor_torque,
-            )
+        applied_torques = np.clip(
+            np.asarray(applied_torques),
+            -self.max_motor_torque,
+            +self.max_motor_torque,
         )
 
         return applied_torques

--- a/tests/test_robot_equivalent_interface.py
+++ b/tests/test_robot_equivalent_interface.py
@@ -149,6 +149,25 @@ class TestRobotEquivalentInterface(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.finger.get_observation(t2 + 2)
 
+    def test_observation_types(self):
+        """Verify that all fields of observation are np.ndarrays."""
+        # Apply a max torque action for one step
+        action = self.finger.Action(
+            torque=[
+                -self.finger.max_motor_torque,
+                -self.finger.max_motor_torque,
+                -self.finger.max_motor_torque,
+            ]
+        )
+        t = self.finger.append_desired_action(action)
+        obs = self.finger.get_observation(t)
+
+        # verify types
+        self.assertIsInstance(obs.torque, np.ndarray)
+        self.assertIsInstance(obs.position, np.ndarray)
+        self.assertIsInstance(obs.velocity, np.ndarray)
+        self.assertIsInstance(obs.tip_force, np.ndarray)
+
     def test_get_desired_action(self):
         # verify that t < 0 is not accepted
         with self.assertRaises(ValueError):
@@ -162,6 +181,12 @@ class TestRobotEquivalentInterface(unittest.TestCase):
 
         np.testing.assert_array_equal(orig_action.torque, action.torque)
         np.testing.assert_array_equal(orig_action.position, action.position)
+
+        # verify types
+        self.assertIsInstance(action.torque, np.ndarray)
+        self.assertIsInstance(action.position, np.ndarray)
+        self.assertIsInstance(action.position_kd, np.ndarray)
+        self.assertIsInstance(action.position_kp, np.ndarray)
 
     def test_get_applied_action(self):
         # verify that t < 0 is not accepted
@@ -180,6 +205,12 @@ class TestRobotEquivalentInterface(unittest.TestCase):
                 self.finger.max_motor_torque,
             ],
         )
+
+        # verify types
+        self.assertIsInstance(applied_action.torque, np.ndarray)
+        self.assertIsInstance(applied_action.position, np.ndarray)
+        self.assertIsInstance(applied_action.position_kd, np.ndarray)
+        self.assertIsInstance(applied_action.position_kp, np.ndarray)
 
     def test_get_timestamp_ms_001(self):
         t = self.finger.append_desired_action(self.finger.Action())


### PR DESCRIPTION
# Description
- Explicitly convert to `np.array` in constructor of `Action`
- Change `SimFinger.__safety_check_torques` to return an array instead of a list.
- Add unit tests to ensure this.